### PR TITLE
add sword2 content type property

### DIFF
--- a/src/main/scala/nl/knaw/dans/deposit/Deposit.scala
+++ b/src/main/scala/nl/knaw/dans/deposit/Deposit.scala
@@ -27,6 +27,7 @@ import nl.knaw.dans.deposit.Deposit._
 import nl.knaw.dans.deposit.SpringfieldPlayMode.SpringfieldPlayMode
 import nl.knaw.dans.deposit.StageState.StageState
 import nl.knaw.dans.deposit.StateLabel.StateLabel
+import nl.knaw.dans.deposit.Sword2ContentType.Sword2ContentType
 import org.joda.time.DateTime
 
 import scala.language.{ implicitConversions, postfixOps }
@@ -447,6 +448,20 @@ class Deposit private(val baseDir: File,
 
   def withoutStageState: Deposit = {
     val newProperties = properties.copy(staged = Staged())
+
+    withDepositProperties(newProperties)
+  }
+
+  def sword2ContentType: Option[Sword2ContentType] = properties.sword2.contentType
+
+  def withSword2ContentType(contentType: Sword2ContentType): Deposit = {
+    val newProperties = properties.copy(sword2 = Sword2(Some(contentType)))
+
+    withDepositProperties(newProperties)
+  }
+
+  def withoutSword2ContentType: Deposit = {
+    val newProperties = properties.copy(sword2 = Sword2())
 
     withDepositProperties(newProperties)
   }

--- a/src/main/scala/nl/knaw/dans/deposit/DepositProperties.scala
+++ b/src/main/scala/nl/knaw/dans/deposit/DepositProperties.scala
@@ -31,7 +31,8 @@ case class DepositProperties(creation: Creation = Creation(),
                              identifier: Identifier = Identifier(),
                              curation: Curation = Curation(),
                              springfield: Springfield = Springfield(),
-                             staged: Staged = Staged()) {
+                             staged: Staged = Staged(),
+                             sword2: Sword2 = Sword2()) {
 
   /**
    * Writes the `DepositProperties` to `file` on the filesystem.
@@ -73,6 +74,8 @@ case class DepositProperties(creation: Creation = Creation(),
       springfield.playMode.foreach(setProperty(sprinfieldPlaymode, _))
 
       staged.state.foreach(state => setProperty(stagedState, state.toString))
+
+      sword2.contentType.foreach(contentType => setProperty(sword2ContentType, contentType.toString))
     }.save(file.toJava)
   }
 }
@@ -101,6 +104,7 @@ object DepositProperties {
   val springfieldCollection = "springfield.collection"
   val sprinfieldPlaymode    = "springfield.playmode"
   val stagedState           = "staged.state"
+  val sword2ContentType     = "easy-sword2.client-message.content-type"
   // @formatter:on
 
   /**
@@ -157,6 +161,7 @@ object DepositProperties {
       curation = Curation.load(properties)
       springfield <- Springfield.load(properties)
       staged <- Staged.load(properties)
-    } yield DepositProperties(creation, state, depositor, ingest, bagStore, identifier, curation, springfield, staged)
+      sword2 <- Sword2.load(properties)
+    } yield DepositProperties(creation, state, depositor, ingest, bagStore, identifier, curation, springfield, staged, sword2)
   }
 }

--- a/src/main/scala/nl/knaw/dans/deposit/Sword2.scala
+++ b/src/main/scala/nl/knaw/dans/deposit/Sword2.scala
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2018 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.deposit
+
+import nl.knaw.dans.deposit.DepositProperties.sword2ContentType
+import nl.knaw.dans.deposit.Sword2ContentType.Sword2ContentType
+import org.apache.commons.configuration.PropertiesConfiguration
+
+import scala.util.Try
+
+object Sword2ContentType extends Enumeration {
+  type Sword2ContentType = Value
+
+  val ZIP: Sword2ContentType = Value("application/zip")
+  val OCTET_STREAM: Sword2ContentType = Value("application/octet-stream")
+}
+
+case class Sword2(contentType: Option[Sword2ContentType] = Option.empty)
+object Sword2 {
+  def load(properties: PropertiesConfiguration): Try[Sword2] = {
+    for {
+      contentType <- readEnumProperty(sword2ContentType, Sword2ContentType)(properties)
+    } yield Sword2(contentType)
+  }
+}

--- a/src/test/resources/test-deposits/v0/simple-deposit/1c2f78a1-26b8-4a40-a873-1073b9f3a56a/deposit.properties
+++ b/src/test/resources/test-deposits/v0/simple-deposit/1c2f78a1-26b8-4a40-a873-1073b9f3a56a/deposit.properties
@@ -19,3 +19,4 @@ springfield.domain=mydomain
 springfield.user=myname
 springfield.playmode=continuous
 staged.state=ARCHIVED
+easy-sword2.client-message.content-type=application/octet-stream

--- a/src/test/scala/nl/knaw/dans/deposit/DepositPropertiesSpec.scala
+++ b/src/test/scala/nl/knaw/dans/deposit/DepositPropertiesSpec.scala
@@ -67,6 +67,8 @@ class DepositPropertiesSpec extends TestSupportFixture
 
     props.staged.state shouldBe empty
 
+    props.sword2.contentType shouldBe empty
+
     // unset fixed DateTime.now
     DateTimeUtils.setCurrentMillisOffset(0L)
   }
@@ -102,6 +104,8 @@ class DepositPropertiesSpec extends TestSupportFixture
     props.springfield.playMode.value shouldBe SpringfieldPlayMode.CONTINUOUS
 
     props.staged.state.value shouldBe StageState.ARCHIVED
+
+    props.sword2.contentType.value shouldBe Sword2ContentType.OCTET_STREAM
   }
 
   it should "read the properties from a deposit.properties with minimal properties" in {
@@ -135,6 +139,8 @@ class DepositPropertiesSpec extends TestSupportFixture
     props.springfield.playMode shouldBe empty
 
     props.staged.state shouldBe empty
+
+    props.sword2.contentType shouldBe empty
   }
 
   it should "fail when the file does not exist" in {

--- a/src/test/scala/nl/knaw/dans/deposit/DepositSpec.scala
+++ b/src/test/scala/nl/knaw/dans/deposit/DepositSpec.scala
@@ -21,7 +21,6 @@ import java.util.{ Date, UUID }
 
 import better.files.File
 import nl.knaw.dans.bag.{ ChecksumAlgorithm, RelativePath }
-import nl.knaw.dans.deposit.Action.update
 import nl.knaw.dans.deposit.fixtures._
 import org.apache.commons.configuration.PropertiesConfiguration
 import org.joda.time.format.ISODateTimeFormat
@@ -1037,6 +1036,28 @@ class DepositSpec extends TestSupportFixture
     val resultDeposit = deposit.withoutStageState
 
     resultDeposit.stageState shouldBe empty
+  }
+
+  "sword2ContentType" should "return the sword2 contentType from deposit.properties" in {
+    val deposit = simpleDepositV0()
+
+    deposit.sword2ContentType.value shouldBe Sword2ContentType.OCTET_STREAM
+  }
+
+  "withSword2ContentType" should "change the sword contentType and return the new DepositProperties" in {
+    val deposit = simpleDepositV0()
+    val contentType = Sword2ContentType.ZIP
+
+    val resultDeposit = deposit.withSword2ContentType(contentType)
+
+    resultDeposit.sword2ContentType.value shouldBe contentType
+  }
+
+  "withoutSword2ContentType" should "remove the sword contentType and return the new DepositProperties" in {
+    val deposit = simpleDepositV0()
+    val resultDeposit = deposit.withoutSword2ContentType
+
+    resultDeposit.sword2ContentType shouldBe empty
   }
 
   "save" should "write changes made to the Bag object in the bag to the deposit on file system" in {

--- a/src/test/scala/nl/knaw/dans/deposit/Sword2Spec.scala
+++ b/src/test/scala/nl/knaw/dans/deposit/Sword2Spec.scala
@@ -20,28 +20,28 @@ import org.apache.commons.configuration.PropertiesConfiguration
 
 import scala.util.{ Failure, Success }
 
-class StagedSpec extends TestSupportFixture {
+class Sword2Spec extends TestSupportFixture {
 
-  "load" should "yield a Staged object with state present" in {
+  "load" should "yield a Sword2 object with contentType present" in {
     val props = new PropertiesConfiguration()
-    props.addProperty("staged.state", "REJECTED")
+    props.addProperty("easy-sword2.client-message.content-type", "application/zip")
 
-    Staged.load(props) should matchPattern { case Success(Staged(Some(StageState.REJECTED))) => }
+    Sword2.load(props) should matchPattern { case Success(Sword2(Some(Sword2ContentType.ZIP))) => }
   }
 
-  it should "yield a Staged object with no state present" in {
+  it should "yield a Sword2 object with no contentType present" in {
     val props = new PropertiesConfiguration()
-    // no staged.state
+    // no easy-sword2.client-message.content-type
 
-    Staged.load(props) should matchPattern { case Success(Staged(None)) => }
+    Sword2.load(props) should matchPattern { case Success(Sword2(None)) => }
   }
 
-  it should "fail when state has an invalid value" in {
+  it should "fail when contentType has an invalid value" in {
     val props = new PropertiesConfiguration()
-    props.addProperty("staged.state", "invalid value")
+    props.addProperty("easy-sword2.client-message.content-type", "invalid value")
 
-    Staged.load(props) should matchPattern {
-      case Failure(NoSuchElementException("No value found for 'invalid value' in field 'staged.state'", _)) =>
+    Sword2.load(props) should matchPattern {
+      case Failure(NoSuchElementException("No value found for 'invalid value' in field 'easy-sword2.client-message.content-type'", _)) =>
     }
   }
 }


### PR DESCRIPTION
Following https://github.com/DANS-KNAW/easy-specs/pull/64 and https://github.com/DANS-KNAW/easy-sword2/pull/123, I added `easy-sword2.client-message.content-type` to `dans-deposit-lib`.

@DANS-KNAW/easy for review